### PR TITLE
Clean code insee widget

### DIFF
--- a/app/codeInsee/Instructions.tsx
+++ b/app/codeInsee/Instructions.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Accordion } from "../../components/Accordion";
+import { NATURE_JURIDIQUE } from "./constants";
 
 export const Instructions = () => {
   const instructions = (
     <>
-      Cette Vue permet d'indiquer le code Insee correspondant à chaque ligne.
+      Cette Vue permet d'indiquer le code de la collectivité correspondant à
+      chaque ligne.
       <br />
       Fonctionnement :
       <ul>
@@ -31,6 +33,32 @@ export const Instructions = () => {
           cette vue.
         </li>
       </ul>
+      <br />
+      Voici la liste des <b>natures juridiques</b> valides dans l'API interrogée
+      et le type de code qui lui correspond. Si une nature juridique est
+      indiquée mais ne correspond à aucune présente dans cette liste elle sera
+      alors ignorée.
+      <br />
+      <table cellSpacing="0">
+        <thead>
+          <tr>
+            <th>Identifiant</th>
+            <th>Nom</th>
+            <th>Type de Code</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.values(NATURE_JURIDIQUE).map((nature) => {
+            return (
+              <tr key={nature.key}>
+                <th>{nature.key}</th>
+                <td>{nature.label}</td>
+                <td>{nature.typeCode}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </>
   );
 

--- a/app/codeInsee/Instructions.tsx
+++ b/app/codeInsee/Instructions.tsx
@@ -13,8 +13,17 @@ export const Instructions = () => {
       <ul>
         <li>
           Indiquer la colonne respondant au nom de la collectivité ainsi que la
-          colonne à remplir pour les code Insee (colonne de type Texte). Il est
+          colonne à remplir pour les codes Insee (colonne de type Texte). Il est
           possible d'indiquer d'autre colonne pour aider à désambiguer.
+        </li>
+        <li>
+          Indiquez si vous souhaitez accepter les codes SIREN en plus des codes
+          INSEE.
+        </li>
+        <li>
+          Si vous n'avez pas indiqué de colonne permettant de désanbiguer sur la
+          nature juridique de la collectivité à rechercher, vous pouvez le
+          définir globalement via la liste déroulante appropriée.
         </li>
         <li>
           Faire une recherche globale afin de faire une première passe sur

--- a/app/codeInsee/SpecificProcessing.tsx
+++ b/app/codeInsee/SpecificProcessing.tsx
@@ -49,7 +49,7 @@ export const SpecificProcessing: FC<{
   };
 
   const recordFindNode = (
-    <div>Le code INSEE de {recordName} a bien été rempli.</div>
+    <div>Le code INSEE/SIREN de {recordName} a bien été rempli.</div>
   );
 
   const choiceBannerNode = record && dirtyData && (
@@ -59,8 +59,9 @@ export const SpecificProcessing: FC<{
       option={{
         choiceValueKey: "code_insee",
         withChoiceTagLegend: true,
-        choiceTagLegend: "Code INSEE",
+        choiceTagLegend: "Code INSEE / SIREN",
         choiceTagKey: "code_insee",
+        choiceTagKey2: "siren_groupement",
       }}
       itemDisplay={(item: NormalizedInseeResult) => {
         return (

--- a/app/codeInsee/constants.ts
+++ b/app/codeInsee/constants.ts
@@ -1,4 +1,5 @@
 import { NoDataMessage } from "../../lib/cleanData/types";
+import { EntiteAdmin } from "./types";
 
 export const TITLE = "Ajouter les codes INSEE à partir d'une localité";
 
@@ -44,4 +45,69 @@ export const NO_DATA_MESSAGES: NoDataMessage = {
     "Afin de traiter la ligne sélectionnée, veuillez renseigner la collectivité recherchée.",
   API_ERROR:
     "Une erreur est survenue lors de l'appel à l'api, veuillez appeler le service technique.",
+};
+
+// Used for addok-admin API
+export const NATURE_JURIDIQUE: {
+  [key: string]: EntiteAdmin;
+} = {
+  COM: { label: "Commune", key: "COM", typeCode: "INSEE" },
+  CA: { label: "Communauté d’agglomération", key: "CA", typeCode: "SIREN" },
+  CC: { label: "Communauté de communes", key: "CC", typeCode: "SIREN" },
+  COLTER: {
+    label: "Collectivités territoriales",
+    key: "COLTER",
+    typeCode: "SIREN",
+  },
+  EPT: {
+    label: "Etablissement public territorial",
+    key: "EPT",
+    typeCode: "SIREN",
+  },
+  SMF: { label: "Syndicat mixte fermé", key: "SMF", typeCode: "SIREN" },
+  SMO: { label: "Syndicat mixte ouvert", key: "SMO", typeCode: "SIREN" },
+  SIVOS: {
+    label: "Syndicat intercommunal à vocation multiple",
+    key: "SIVOS",
+    typeCode: "SIREN",
+  },
+  SIVU: {
+    label: "Syndicat intercommunal à vocation unique",
+    key: "SIVU",
+    typeCode: "SIREN",
+  },
+  METRO: { label: "Métropole", key: "METRO", typeCode: "SIREN" },
+  DEP: { label: "Département", key: "DEP", typeCode: "INSEE" },
+  REG: { label: "Région", key: "REG", typeCode: "INSEE" },
+};
+
+// Used for api-geo API
+export const DECOUPAGE_ADMIN: {
+  [key: string]: EntiteAdmin;
+} = {
+  COM: {
+    label: "communes",
+    apiGeoUrl: "communes",
+    key: "COM",
+    typeCode: "INSEE",
+  },
+  COM_ASSOCIES_ET_DELEGUEES: {
+    label: "communes associées et déléguées",
+    apiGeoUrl: "communes_associees_deleguees",
+    key: "COM_ASSOCIES_ET_DELEGUEES",
+    typeCode: "INSEE",
+  },
+  EPCI: { label: "epci", apiGeoUrl: "epcis", key: "EPCI", typeCode: "SIREN" },
+  DEPT: {
+    label: "départements",
+    apiGeoUrl: "departements",
+    key: "DEPT",
+    typeCode: "INSEE",
+  },
+  REG: {
+    label: "régions",
+    apiGeoUrl: "regions",
+    key: "REG",
+    typeCode: "INSEE",
+  },
 };

--- a/app/codeInsee/constants.ts
+++ b/app/codeInsee/constants.ts
@@ -1,7 +1,8 @@
 import { NoDataMessage } from "../../lib/cleanData/types";
 import { EntiteAdmin } from "./types";
 
-export const TITLE = "Ajouter les codes INSEE à partir d'une localité";
+export const TITLE =
+  "Ajouter les codes INSEE (et SIREN) à partir d'une localité";
 
 export const COLUMN_MAPPING_NAMES = {
   COLLECTIVITE: {

--- a/app/codeInsee/lib.ts
+++ b/app/codeInsee/lib.ts
@@ -1,5 +1,9 @@
 import { RowRecord } from "grist/GristData";
-import { COLUMN_MAPPING_NAMES, NO_DATA_MESSAGES } from "./constants";
+import {
+  COLUMN_MAPPING_NAMES,
+  NATURE_JURIDIQUE,
+  NO_DATA_MESSAGES,
+} from "./constants";
 import { NormalizedInseeResult, NormalizedInseeResults } from "./types";
 import { WidgetColumnMap } from "grist/CustomSectionAPI";
 import { MappedRecord } from "../../lib/util/types";
@@ -47,10 +51,11 @@ export const getInseeCodeResults = async (
       const departement = mappedRecord[COLUMN_MAPPING_NAMES.DEPARTEMENT.name];
       const natureJuridique =
         mappedRecord[COLUMN_MAPPING_NAMES.NATURE_JURIDIQUE.name];
+      // natureJuridique is taken into account only if it's a valide value
       inseeCodeResults = await callInseeCodeApi(
         collectivite,
         departement,
-        natureJuridique,
+        NATURE_JURIDIQUE[natureJuridique] ? natureJuridique : undefined,
       );
       if (inseeCodeResults === undefined) {
         console.error(

--- a/app/codeInsee/lib.ts
+++ b/app/codeInsee/lib.ts
@@ -56,7 +56,7 @@ export const getInseeCodeResults = async (
       const departement = mappedRecord[COLUMN_MAPPING_NAMES.DEPARTEMENT.name];
       const natureJuridique =
         mappedRecord[COLUMN_MAPPING_NAMES.NATURE_JURIDIQUE.name];
-      // natureJuridique is taken into account only if it's a valide value, otherwize we use the general one if it's define
+      // natureJuridique is taken into account only if it's a valid value, otherwise we use the general one if it's defined
       inseeCodeResults = await callInseeCodeApi(
         collectivite,
         departement,

--- a/app/codeInsee/page.tsx
+++ b/app/codeInsee/page.tsx
@@ -99,7 +99,15 @@ const InseeCode = () => {
   const recordResearch = async () => {
     if (record) {
       setCurrentStep("specific_processing");
-      // TODO : delete data corresponding to this record in dirty and noResult states
+      // Delete data corresponding to this record in dirty and noResult states
+      setDirtyData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
+      setNoResultData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
       const recordUncleanedData = await getInseeCodeResultsForRecord(
         record,
         mappings!,

--- a/app/codeInsee/types.ts
+++ b/app/codeInsee/types.ts
@@ -11,3 +11,10 @@ export type NormalizedInseeResults = {
   results: NormalizedInseeResult[];
   query: string;
 };
+
+export type EntiteAdmin = {
+  label: string;
+  apiGeoUrl?: string;
+  key: string;
+  typeCode: string;
+};

--- a/app/codeSiren/page.tsx
+++ b/app/codeSiren/page.tsx
@@ -107,7 +107,15 @@ const InseeCode = () => {
   const recordResearch = async () => {
     if (record) {
       setCurrentStep("specific_processing");
-      // TODO : delete data corresponding to this record in dirty and noResult states
+      // Delete data corresponding to this record in dirty and noResult states
+      setDirtyData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
+      setNoResultData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
       const recordUncleanedData = await getSirenCodeResultsForRecord(
         record,
         mappings!,

--- a/app/geocode/page.tsx
+++ b/app/geocode/page.tsx
@@ -99,7 +99,15 @@ const GeoCodeur = () => {
   const recordResearch = async () => {
     if (record) {
       setCurrentStep("specific_processing");
-      // TODO : delete data corresponding to this record in dirty and noResult states
+      // Delete data corresponding to this record in dirty and noResult states
+      setDirtyData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
+      setNoResultData((prevState) => {
+        delete prevState[record.id];
+        return prevState;
+      });
       const recordUncleanedData = await getGeoCodeResultsForRecord(
         record,
         mappings!,

--- a/components/DropDownParams.tsx
+++ b/components/DropDownParams.tsx
@@ -12,8 +12,8 @@ type DropDownItem = {
 export const DropDownParams: FC<{
   label: string;
   list: DropDownItem[];
-  selected: DropDownItem;
-  onChange: (elem: DropDownItem) => void;
+  selected: DropDownItem | null;
+  onChange: (elem: DropDownItem | null) => void;
 }> = ({ label, list, selected, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -21,7 +21,7 @@ export const DropDownParams: FC<{
     setIsOpen(!isOpen);
   };
 
-  const closeDropdown = (elem: DropDownItem) => {
+  const closeDropdown = (elem: DropDownItem | null) => {
     onChange(elem);
     setIsOpen(false);
   };
@@ -30,7 +30,7 @@ export const DropDownParams: FC<{
       {label}
       <div className="dropdown">
         <button type="button" className="secondary" onClick={toggleDropdown}>
-          <span>{selected.label} </span>
+          <span>{selected ? selected.label : "Selectionner un choix"} </span>
           <span className="icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
               {isOpen ? (
@@ -55,6 +55,15 @@ export const DropDownParams: FC<{
               aria-orientation="vertical"
               aria-labelledby="options-menu"
             >
+              <li>
+                <a
+                  href="#"
+                  className="dropdown-elem dropdown-no-selected"
+                  onClick={() => closeDropdown(null)}
+                >
+                  Selectionner un choix
+                </a>
+              </li>
               {list.map((elem, index) => {
                 return (
                   <li key={index}>

--- a/components/cleanData/GenericChoiceBanner.tsx
+++ b/components/cleanData/GenericChoiceBanner.tsx
@@ -10,6 +10,7 @@ type Option = {
   withChoiceTagLegend: boolean;
   choiceTagLegend: string;
   choiceTagKey: string;
+  choiceTagKey2?: string;
 };
 
 type GenericChoiceBannerParams<NormalizedResult extends KeyValue> = {
@@ -71,7 +72,10 @@ function GenericChoiceBanner<NormalizedResult extends KeyValue>({
                   </label>
                 </div>
                 {option.withChoiceTagLegend && (
-                  <div className="tag info">{item[option.choiceTagKey]}</div>
+                  <div className="tag info">
+                    {item[option.choiceTagKey] ||
+                      (option.choiceTagKey2 && item[option.choiceTagKey2])}
+                  </div>
                 )}
               </div>
             </div>

--- a/components/dropDownParams.css
+++ b/components/dropDownParams.css
@@ -19,15 +19,17 @@
 .dropdown-list {
   position: absolute;
   top: 100%;
-  left: 0;
-  width: 30rem;
+  right: 0;
   box-shadow: 0 10px 15px -3px black;
   background-color: white;
   border-radius: 0.5rem;
+  text-align: left;
+  width: max-content;
 }
 
 .dropdown-list ul {
   list-style-type: none;
+  padding: 5px;
 }
 
 .dropdown-elem {
@@ -40,4 +42,12 @@
 .dropdown-elem:hover {
   color: black;
   background-color: var(--lighter-grey, #F7F7F7);
+}
+
+.dropdown-no-selected {
+  color: var(--light-grey, #D9D9D9);
+}
+
+.dropdown-no-selected:hover {
+  color: var(--grey, #686565);
 }

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -1,17 +1,5 @@
 import { KeyAsString } from "./types";
 
-export const NATURE_JURIDIQUE: KeyAsString = {
-  COM: "Commune",
-  CA: "Communauté d’agglomération",
-  CC: "Communauté de communes",
-  SIVU: "SIVU",
-  DEP: "département",
-  COLTER: "Collectivités territoriales",
-  SMO: "SMO",
-  SMF: "SMF",
-  SIVOS: "SIVOS",
-};
-
 export const DEPT: KeyAsString = {
   "01": "Auvergne-Rhône-Alpes",
   "02": "Hauts-de-France",

--- a/styles/index.css
+++ b/styles/index.css
@@ -227,3 +227,20 @@ footer {
   height: 80px;
   text-align: left;
 }
+
+table {
+  width: 100%;
+  border: 1px solid #333;
+}
+
+td,
+th {
+  border: 1px solid #333;
+  padding: 3px;
+}
+
+thead,
+tfoot {
+  background-color: var(--green, #009058);
+  color: #fff;
+}


### PR DESCRIPTION
# Context
**Widget CodeInsee**
Après une hésitation entre l'utilisation de l'api addok-admin et api-geo, dans un premier temps nous allons garder addok-admin. Mais il faut lisser le comportement suite à une démo à Nicolas et Vincent.


# Réaliser
- Ajouter la liste complète de "nature juridique" utilisable dans l'API dans la constante `NATURE_JURIDIQUE`. Afficher cette liste dans les instructions et vérifier que la nature_juridique indiqué dans le tableau est valide avant de procéder à l'appel à l'API.
- Supprimer les data d'un record de la liste `dirty` et `noResult` lorsqu'on réitère une recherche spécifique. Ca permet de ne pas avoir un affichage qui correspond à la recherche précédente alors qu'on vient de changer des paramètres.
-  Demander à l'utilisateur si il accepte de remplir sa colonne avec des code SIREN ou si il souhaite exclusivement des codes INSEE
- Si le mapping pour la colonne "Nature_juridique" n'est pas renseigné alors propose à l'utilisateur de sélectionner une nature juridique qui serait la même pour l'ensemble du tableau (optionnel) 
- Dans le `choiceBanner` afficher le code SIREN peu importe si on l'accepte ou pas 