### PR TITLE
Update widget-list.json

### DIFF
--- a/public/widget-list.json
+++ b/public/widget-list.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Carte",
-    "url": "https://infrastructure.pages.sit.incubateur.tech/grist-widgets/carte/index.html",
+    "url": "https://infrastructure.pages.gitlab.donnees.incubateur.anct.gouv.fr/grist-widgets/carte/index.html",
     "widgetId": "@anct/widget-map#map",
     "published": true,
     "accessLevel": "read table"


### PR DESCRIPTION
suite à migration de l'instance gitlab de données et territoires ce widget devrait peut-être être supprimé au profit du widget carte de gristlabs (Maps)