### PR TITLE
Add autoupdate-widget-list workflow to track GristLabs widgets

### DIFF
--- a/.github/workflows/autoupdate-widget-list.yml
+++ b/.github/workflows/autoupdate-widget-list.yml
@@ -1,0 +1,27 @@
+name: Update Widget list
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 10 * * *'
+
+jobs:
+  update-widgets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update widget list
+        run: |
+          curl -s https://gristlabs.github.io/grist-widget/manifest.json | \
+            jq \
+              --argfile gl /dev/stdin \
+              --argfile cur ./public/widget-list.json \
+              -n '$cur + [($gl[] | select(([$gl[].url] - [$cur[].url])[] == .url))]' > ./public/widget-list.json2 \
+              && mv ./public/widget-list.json{2,}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: Mise à jour automatique de la liste des widgets de Grist Labs
+          title: Mise à jour automatique de la liste des widgets de Grist Labs
+          body: Mise à jour des widgets mises à disposition par Grist Labs et fusion avec nos propres widgets
+          branch: update-widget-list
+          base: main


### PR DESCRIPTION
# Contexte

Nous maitenons notre propre liste de widgets, mais nous nous désynchronisons avec la liste des widgets mise à disposition par Grist Labs

# Solution proposée

Au lieu de faire une mise à jour manuelle de temps à autre, j'ai opté pour une solution automatisée (ce qui me permet par ailleurs de m'intéresser aux Github actions).

Cette solution consiste à lancer tous les jours une commande qui rajoute la liste des widgets manquants dans notre liste actuelle, en utilisant la commande [jq](https://jqlang.github.io/jq/manual) pour manipuler et requêter dans du json.

Voici [un exemple de PR que ça ouvre](https://github.com/fflorent/grist-custom-widgets-fr-admin/pull/1)