### PR TITLE
autoupdate: use jq with --slurpfile instead of --argfile (removed now)

### DIFF
--- a/.github/workflows/autoupdate-widget-list.yml
+++ b/.github/workflows/autoupdate-widget-list.yml
@@ -13,9 +13,9 @@ jobs:
         run: |
           curl -s https://gristlabs.github.io/grist-widget/manifest.json | \
             jq \
-              --argfile gl /dev/stdin \
-              --argfile cur ./public/widget-list.json \
-              -n '$cur + [($gl[] | select(([$gl[].url] - [$cur[].url])[] == .url))]' > ./public/widget-list.json2 \
+            --slurpfile gl /dev/stdin \
+            --slurpfile cur ./public/widget-list.json \
+              -n '$cur[0] + [($gl[0][] | select(([$gl[0][].url] - [$cur[0][].url])[] == .url))]' > ./public/widget-list.json2 \
               && mv ./public/widget-list.json{2,}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
[--argfile](https://github.com/jqlang/jq/pull/2768) option was deprecated and has been removed since version 1.7. It is suggested now to use `--slurpfile` instead. This PR fixes errors we have been notified for some time.

Edit: le fix semble fonctionné, il a permis de générer cette PR (que j'ai mergée entre temps): https://github.com/betagouv/grist-custom-widgets-fr-admin/pull/24