### PR TITLE
dependabot: simplify update checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,3 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    groups:
-      npm:
-        dependency-type: production
-        applies-to: "security-updates"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
It seems like it is difficult to have different frequency for dependency updates depending on security risks.

Previously we wanted to check the updates weekly only when their existed security risks, and otherwise trigger a monthly check.

But it seems like it is not possible, as quoted an error from dependabot:
> Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.

So let's just check the updates once a month.